### PR TITLE
Updated gemspec for Rails 4 compatibility; added installation instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ For more information about Tipsy, visit http://onehackoranother.com/projects/jqu
 
 1. Add the gem to your `Gemfile`:
 
-    gem 'tipsy-rails', git: 'git://github.com/thinkswan/tipsy-rails.git', branch: 'rails4'
+        gem 'tipsy-rails', git: 'git://github.com/thinkswan/tipsy-rails.git', branch: 'rails4'
 
 2. Require the CSS in your `application.css` manifest:
 
-    *= require tipsy
+        *= require tipsy
 
 3. Require the JS in your `application.js` manifest:
 
-    //= require tipsy
+        //= require tipsy

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # tipsy-rails
 
-This gem provides the jQuery Tipsy plugin for your Rails 3.1 app.
+This gem provides the jQuery Tipsy plugin for your Rails 3.1+ app.
 
 For more information about Tipsy, visit http://onehackoranother.com/projects/jquery/tipsy/
+
+## Installation
+
+1. Add the gem to your `Gemfile`:
+
+    gem 'tipsy-rails', git: 'git://github.com/thinkswan/tipsy-rails.git', branch: 'rails4'
+
+2. Require the CSS in your `application.css` manifest:
+
+    *= require tipsy
+
+3. Require the JS in your `application.js` manifest:
+
+    //= require tipsy

--- a/tipsy-rails.gemspec
+++ b/tipsy-rails.gemspec
@@ -13,10 +13,10 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "railties", "~> 3.0"
+  s.add_dependency "railties", ">= 3.0"
   s.add_dependency "sass-rails"
   s.add_development_dependency "bundler", "~> 1.1.0"
-  s.add_development_dependency "rails",   "~> 3.0"
+  s.add_development_dependency "rails",   ">= 3.0"
 
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files`.split("\n").select{|f| f =~ /^bin/}


### PR DESCRIPTION
I'm using this in a Rails 4 project, so I updated the gemspec to allow that. It will still work in Rails 3.1+.

I also added installation instructions for the asset pipeline to the readme.

Tested this and it works.
