### PR TITLE
Fix asset precompile path

### DIFF
--- a/lib/tipsy/rails/engine.rb
+++ b/lib/tipsy/rails/engine.rb
@@ -2,7 +2,7 @@ module Tipsy
   module Rails
     class Engine < ::Rails::Engine
       initializer "tipsy-rails.assets.precompile" do |app|
-        app.config.assets.precompile += %w(tipsy.gif)
+        app.config.assets.precompile += %w(tipsy/tipsy.gif)
       end
     end
   end

--- a/lib/tipsy/rails/version.rb
+++ b/lib/tipsy/rails/version.rb
@@ -1,6 +1,6 @@
 module Tipsy
   module Rails
-    VERSION = "1.0.5"
+    VERSION = "1.0.6"
     TIPSY_VERSION = "1.0.0a"
   end
 end


### PR DESCRIPTION
The Rails 4 precompile change I previously suggested wasn't working because the path of the asset was incorrect. This fixes that. Bumped the gem to 1.0.6.
